### PR TITLE
Add Chrono24 scraping API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# watch_scraper
+# Watch Scraper
+
+Simple API to scrape watch price information from Chrono24 and store it in a SQLite database.
+
+## Endpoints
+
+* `POST /scrape?query=<keyword>` - Scrape Chrono24 for the given keyword and store watch names and prices.
+* `GET /watches` - List watches stored in the database.
+
+## Running
+
+Install dependencies from `requirements.txt` and run the API with a WSGI server such as `uvicorn`:
+
+```bash
+pip install -r requirements.txt
+uvicorn api:app --reload
+```
+
+## Tests
+
+Tests rely on mocked HTTP responses and a temporary SQLite database. Execute them with:
+
+```bash
+pytest
+```

--- a/api.py
+++ b/api.py
@@ -1,0 +1,24 @@
+from fastapi import FastAPI, HTTPException
+from scraper import fetch_watch_prices
+from database import init_db, insert_watches, get_watches
+
+app = FastAPI()
+
+
+@app.on_event("startup")
+def startup() -> None:
+    init_db()
+
+
+@app.post("/scrape")
+def scrape(query: str):
+    watches = fetch_watch_prices(query)
+    if not watches:
+        raise HTTPException(status_code=404, detail="No watches found")
+    inserted = insert_watches(watches)
+    return {"count": inserted}
+
+
+@app.get("/watches")
+def list_watches():
+    return get_watches()

--- a/database.py
+++ b/database.py
@@ -1,0 +1,54 @@
+import sqlite3
+from typing import List, Dict
+
+DB_NAME = "watches.db"
+
+
+def init_db() -> None:
+    """Initialize the SQLite database."""
+    conn = sqlite3.connect(DB_NAME)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS watches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            price TEXT NOT NULL
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def insert_watches(watches: List[Dict[str, str]]) -> int:
+    """Insert a list of watches into the database.
+
+    Args:
+        watches: List of dictionaries with ``name`` and ``price``.
+
+    Returns:
+        Number of inserted rows.
+    """
+    if not watches:
+        return 0
+    conn = sqlite3.connect(DB_NAME)
+    cur = conn.cursor()
+    cur.executemany(
+        "INSERT INTO watches (name, price) VALUES (?, ?)",
+        [(w["name"], w["price"]) for w in watches],
+    )
+    conn.commit()
+    rowcount = cur.rowcount
+    conn.close()
+    return rowcount
+
+
+def get_watches() -> List[Dict[str, str]]:
+    """Retrieve all stored watches."""
+    conn = sqlite3.connect(DB_NAME)
+    cur = conn.cursor()
+    cur.execute("SELECT name, price FROM watches")
+    rows = cur.fetchall()
+    conn.close()
+    return [{"name": name, "price": price} for name, price in rows]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+requests
+beautifulsoup4
+pytest

--- a/scraper.py
+++ b/scraper.py
@@ -1,0 +1,32 @@
+import requests
+from bs4 import BeautifulSoup
+from typing import List, Dict
+
+BASE_URL = "https://www.chrono24.com/search/index.htm"
+
+
+def fetch_watch_prices(query: str) -> List[Dict[str, str]]:
+    """Fetch watch listings from Chrono24 search results.
+
+    Args:
+        query: Search string for the watch model or brand.
+
+    Returns:
+        A list of dictionaries with watch ``name`` and ``price`` fields.
+    """
+    headers = {"User-Agent": "Mozilla/5.0"}
+    params = {"query": query, "dosearch": "true"}
+    response = requests.get(BASE_URL, params=params, headers=headers, timeout=10)
+    response.raise_for_status()
+
+    soup = BeautifulSoup(response.text, "html.parser")
+    watches: List[Dict[str, str]] = []
+    for item in soup.select("article.article-item"):
+        name_tag = item.select_one(".article-name")
+        price_tag = item.select_one(".article-price")
+        if not name_tag or not price_tag:
+            continue
+        name = name_tag.get_text(strip=True)
+        price = price_tag.get_text(strip=True)
+        watches.append({"name": name, "price": price})
+    return watches

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,0 +1,58 @@
+import os
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+import scraper
+import database
+from api import app
+
+SAMPLE_HTML = """
+<html><body>
+<article class='article-item'>
+  <div class='article-name'>Rolex Submariner</div>
+  <div class='article-price'>USD 10000</div>
+</article>
+<article class='article-item'>
+  <div class='article-name'>Omega Speedmaster</div>
+  <div class='article-price'>EUR 5000</div>
+</article>
+</body></html>
+"""
+
+
+class DummyResponse:
+    def __init__(self, text: str):
+        self.text = text
+
+    def raise_for_status(self):
+        pass
+
+
+def mock_get(url, params=None, headers=None, timeout=10):
+    return DummyResponse(SAMPLE_HTML)
+
+
+def test_fetch_watch_prices():
+    with patch("scraper.requests.get", mock_get):
+        results = scraper.fetch_watch_prices("rolex")
+    assert len(results) == 2
+    assert results[0]["name"] == "Rolex Submariner"
+    assert results[0]["price"] == "USD 10000"
+
+
+def test_api_scrape_and_list(tmp_path, monkeypatch):
+    # Use temporary DB for the test
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr(database, "DB_NAME", str(db_path))
+
+    with patch("scraper.requests.get", mock_get):
+        with TestClient(app) as client:
+            response = client.post("/scrape", params={"query": "rolex"})
+            assert response.status_code == 200
+            assert response.json() == {"count": 2}
+
+            response = client.get("/watches")
+            assert response.status_code == 200
+            data = response.json()
+            assert len(data) == 2
+            assert data[1]["name"] == "Omega Speedmaster"


### PR DESCRIPTION
## Summary
- implement Chrono24 scraper using requests and BeautifulSoup
- add FastAPI endpoints to scrape and list stored watches
- persist watch data in SQLite and document usage
- include tests with mocked HTTP responses

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_689ac86c370483278a9076c41d9af4dd