### PR TITLE
Use local MongoDB default port

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Watch Scraper
 
-Simple API to scrape watch price information from Chrono24 and store it in a SQLite database.
+Simple API to scrape watch price information from Chrono24 and store it in a local MongoDB database running on the default port (27017).
 
 ## Endpoints
 
@@ -9,7 +9,7 @@ Simple API to scrape watch price information from Chrono24 and store it in a SQL
 
 ## Running
 
-Install dependencies from `requirements.txt` and run the API with a WSGI server such as `uvicorn`:
+Install dependencies from `requirements.txt`, ensure a MongoDB instance is running locally on port 27017, and run the API with a WSGI server such as `uvicorn`:
 
 ```bash
 pip install -r requirements.txt
@@ -18,7 +18,7 @@ uvicorn api:app --reload
 
 ## Tests
 
-Tests rely on mocked HTTP responses and a temporary SQLite database. Execute them with:
+Tests rely on mocked HTTP responses and an in-memory MongoDB stub. Execute them with:
 
 ```bash
 pytest

--- a/database.py
+++ b/database.py
@@ -14,7 +14,8 @@ def init_db() -> None:
     """Initialize the MongoDB connection and ensure indexes exist."""
     global client
     if client is None:
-        client = MongoClient()
+        # Connect to a local MongoDB instance on the default port (27017)
+        client = MongoClient("mongodb://localhost:27017")
     client[DB_NAME][COLLECTION_NAME].create_index("name")
 
 


### PR DESCRIPTION
## Summary
- Explicitly connect to MongoDB at localhost:27017
- Update README to reflect local MongoDB usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b64d0694b48327bf77ca1c8c8fc551