### PR TITLE
Handle fetch errors and use realistic headers

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, HTTPException
+from requests import HTTPError
 from scraper import fetch_watch_prices
 from database import init_db, insert_watches, get_watches
 
@@ -12,7 +13,14 @@ def startup() -> None:
 
 @app.post("/scrape")
 def scrape(query: str, source: str = "chrono24"):
-    watches = fetch_watch_prices(query, source)
+    try:
+        watches = fetch_watch_prices(query, source)
+    except HTTPError as exc:
+        status = exc.response.status_code if exc.response else 502
+        detail = f"Failed to fetch data from {source}: {exc}"
+        raise HTTPException(status_code=status, detail=detail) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
     if not watches:
         raise HTTPException(status_code=404, detail="No watches found")
     inserted = insert_watches(watches)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ fastapi
 uvicorn
 requests
 beautifulsoup4
+cloudscraper
 pytest

--- a/scraper.py
+++ b/scraper.py
@@ -3,7 +3,13 @@
 from typing import List, Dict
 
 import requests
+from requests import HTTPError
 from bs4 import BeautifulSoup
+
+try:  # Optional dependency for bypassing basic anti-bot protections
+    import cloudscraper
+except Exception:  # pragma: no cover - fallback when library is unavailable
+    cloudscraper = None
 
 BASE_URLS = {
     "chrono24": "https://www.chrono24.com/search/index.htm",
@@ -23,11 +29,29 @@ def fetch_watch_prices(query: str, source: str = "chrono24") -> List[Dict[str, s
         A list of dictionaries with watch ``name``, ``price``, ``details`` and ``source`` fields.
     """
 
-    headers = {"User-Agent": "Mozilla/5.0"}
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/115.0.0.0 Safari/537.36"
+        ),
+        "Accept": (
+            "text/html,application/xhtml+xml,application/xml;q=0.9," "image/avif,image/webp,image/apng,*/*;q=0.8"
+        ),
+        "Accept-Language": "en-US,en;q=0.9",
+    }
     url = BASE_URLS.get(source, BASE_URLS["chrono24"])
     params = {"query": query, "dosearch": "true"} if source == "chrono24" else None
-    response = requests.get(url, params=params, headers=headers, timeout=10)
-    response.raise_for_status()
+    try:
+        response = requests.get(url, params=params, headers=headers, timeout=10)
+        if getattr(response, "status_code", None) == 403 and cloudscraper is not None:
+            scraper = cloudscraper.create_scraper()
+            response = scraper.get(url, params=params, headers=headers, timeout=10)
+        response.raise_for_status()
+    except HTTPError:
+        raise
+    except requests.RequestException as exc:  # pragma: no cover - network error handling
+        raise RuntimeError(f"Failed to fetch data from {source}: {exc}") from exc
 
     soup = BeautifulSoup(response.text, "html.parser")
     watches: List[Dict[str, str]] = []


### PR DESCRIPTION
## Summary
- Use full browser-like headers and catch request issues in scraper
- Convert fetch failures into HTTP errors instead of crashing
- Propagate remote status codes and retry 403s with optional anti-bot helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b66e34e2fc8327a396aef9d7b94b3e